### PR TITLE
feat: Mx impl brandon

### DIFF
--- a/fms_mo/modules/bmm.py
+++ b/fms_mo/modules/bmm.py
@@ -754,6 +754,8 @@ QBmm_modules = (
     QMatmulDebug,
     QBmmINT8Deploy,
 )
+if available_packages["mx"]:
+    QBmm_modules += (QBmmMX,)
 
 
 def isinstance_qbmm(module):

--- a/fms_mo/modules/bmm.py
+++ b/fms_mo/modules/bmm.py
@@ -748,6 +748,7 @@ class QBmmINT8Deploy(nn.Module):
         return x.to(m1.dtype)
 
 
+# KEEP THIS AT END OF FILE - classes must be declared
 QBmm_modules = (
     QBmm,
     QMatmulDebug,

--- a/fms_mo/modules/conv.py
+++ b/fms_mo/modules/conv.py
@@ -1515,6 +1515,7 @@ class QConv2d_cutlass_i8i32_nt(nn.Conv2d):
         return output.to(input_dtype)
 
 
+# KEEP THIS AT END OF FILE - classes must be declared
 QConv2d_modules = (
     QConv2d,
     DetQConv2d,

--- a/fms_mo/modules/linear.py
+++ b/fms_mo/modules/linear.py
@@ -1769,29 +1769,6 @@ except ModuleNotFoundError:
         "QLinearExv1WI4AF16 and QLinearExv2WI4AF16 wrappers will not be available."
     )
 
-QLinear_modules = (
-    QLinear,
-    QLinearFPout,
-    QLinearDebug,
-    QLinearW4A32Debug,
-    QLinearINT8Deploy,
-    QLinearCublasI8I32NT,
-    QLinearCutlassI8I32NT,
-)
-
-
-def isinstance_qlinear(module):
-    """
-    Checks if the given module is one of the available quantized linear classes.
-
-    Args:
-        module (nn.Module): The module to check.
-
-    Returns:
-        bool: True if the module is a quantized linear class, False otherwise.
-    """
-    return isinstance(module, QLinear_modules)
-
 
 class LinearFuncFPxFwdBwd(torch.autograd.Function):
     """Linear function using FP24 accumulation, experimental only.
@@ -2117,3 +2094,30 @@ if available_packages["mx"]:
                 f"blk_size={self.mx_specs['block_size']}"
             )
             return repr_str
+
+
+# KEEP THIS AT END OF FILE - classes must be declared
+QLinear_modules = (
+    QLinear,
+    QLinearFPout,
+    QLinearDebug,
+    QLinearW4A32Debug,
+    QLinearINT8Deploy,
+    QLinearCublasI8I32NT,
+    QLinearCutlassI8I32NT,
+)
+if available_packages["mx"]:
+    QLinear_modules += (QLinearMX,)
+
+
+def isinstance_qlinear(module):
+    """
+    Checks if the given module is one of the available quantized linear classes.
+
+    Args:
+        module (nn.Module): The module to check.
+
+    Returns:
+        bool: True if the module is a quantized linear class, False otherwise.
+    """
+    return isinstance(module, QLinear_modules)

--- a/fms_mo/modules/lstm.py
+++ b/fms_mo/modules/lstm.py
@@ -508,6 +508,7 @@ class QLSTM(nn.LSTM):
         return expr
 
 
+# KEEP THIS AT END OF FILE - classes must be declared
 QLSTM_modules = (QLSTM,)
 
 

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -23,15 +23,27 @@ import os
 
 # Third Party
 from torchvision.io import read_image
-from torchvision.models import ResNet50_Weights, ViT_B_16_Weights, resnet50, vit_b_16
-from transformers import BertModel, BertTokenizer
+from torchvision.models import (
+    resnet50,
+    ResNet50_Weights,
+    vit_b_16,
+    ViT_B_16_Weights,
+)
+from transformers import (
+    BertModel,
+    BertTokenizer,
+)
 import pytest
 import torch
+import torch.nn.functional as F
+import numpy as np
 
 # Local
 # fms_mo imports
 from fms_mo import qconfig_init
 from fms_mo.modules import QLSTM, QConv2d, QConvTranspose2d, QLinear
+from fms_mo.utils.import_utils import available_packages
+from fms_mo.utils.qconfig_utils import get_mx_specs_defaults, set_mx_specs
 
 ########################
 # check_config Fixtures #
@@ -309,6 +321,41 @@ def not_which2patch_contextmanager_settings():
     """
     return ["torch.vmm", "torch.natnul", "None"]
 
+@pytest.fixture(scope="session")
+def bad_mx_specs_settings():
+    """
+    Get list of invalid mx_spec key,value pairs
+
+    Returns:
+        list: invalid mx_spec list
+    """
+    return [
+        ("w_elem_format", "fp8_e5m3"),
+        ("a_elem_format", "fp8_m4e3"),
+        ("scale_bits", False),
+        ("block_size", "32"),
+        ("bfloat", [16]),
+        ("round", "bankers"),
+        ("custom_cuda", "yes"),
+    ]
+
+@pytest.fixture(scope="session")
+def bad_mx_config_settings():
+    """
+    Get list of invalid mx config key,value pairs for config and mx_specs
+
+    Returns:
+        list: invalid mx_spec list
+    """
+    return [
+        ("qw_mode", "w_elem_format", "mx_fp8_e5m3", "fp8_e5m3"),
+        ("qa_mode", "a_elem_format", "mx_fp8_m4e3", "fp8_m4e3"),
+        ("mx_scale_bits", "scale_bits", False, False),
+        ("mx_block_size", "block_size", "32", "32"),
+        ("mx_bfloat", "bfloat", {16}, {16}),
+        ("mx_round", "round", "bankers", "bankers"),
+        ("mx_custom_cuda", "custom_cuda", "yes", "yes"),
+    ]
 
 ################################
 # Toy Model Classes + Fixtures #
@@ -425,7 +472,6 @@ class ToyModel4(torch.nn.Module):
         out = self.third_layer(out)
         out = self.fourth_layer(out)
         return out
-
 
 model_fp32_params = [
     ToyModel1(),
@@ -765,6 +811,7 @@ def num_bits_weight_fp16(request):
 # Note: All configs require deepcopy, as we will be modifying them for various tests
 
 default_config_params = [qconfig_init()]
+mx_config_params = [qconfig_init(use_mx=True)]
 
 
 @pytest.fixture(scope="function", params=default_config_params)
@@ -780,6 +827,63 @@ def config_fp32(request):
     """
     qconfig = request.param
     return deepcopy(qconfig)
+
+@pytest.fixture(scope="function", params=default_config_params)
+def config_fp32_mx(request):
+    """
+    Create fp32 qconfig w/ mx_specs vars set in qconfig.
+    
+    Args:
+        request (dict): qconfig_init
+
+    Returns:
+        dict: qconfig_init
+    """
+    qconfig = deepcopy(request.param)
+    mx_specs = get_mx_specs_defaults()
+
+    # print(f"fixture qcfg before {qconfig=}")
+    # Set config vars prefixed w/ "mx_"
+    for key, val in mx_specs.items():
+        qconfig["mx_" + key] = val
+
+    # Only 1 variable that has "mx_" prefix from MX lib
+    qconfig["mx_flush_fp32_subnorms"] = qconfig["mx_mx_flush_fp32_subnorms"]
+    del qconfig["mx_mx_flush_fp32_subnorms"]
+
+    # Move x_elem_format to q_modes and delete mx_x_elem_format
+    # Needs prefix settings to avoid collision w/ fms_mo modes
+    qconfig["qa_mode"] = "mx_" + qconfig["mx_a_elem_format"]
+    qconfig["qw_mode"] = "mx_" + qconfig["mx_w_elem_format"]
+    del qconfig["mx_a_elem_format"]
+    del qconfig["mx_w_elem_format"]
+
+    # Set mx_specs as if we ran qconfig_init
+    # set_mx_specs(qconfig)
+
+    # print(f"fixture qcfg after", qconfig["mx_specs"])
+
+    return qconfig
+
+@pytest.fixture(scope="function", params=mx_config_params)
+def config_fp32_mx_specs(request):
+    """
+    Create fp32 qconfig w/ mx_specs.
+    
+
+    Args:
+        request (dict): qconfig_init
+
+    Returns:
+        dict: qconfig_init
+    """
+    qconfig = deepcopy(request.param)
+    qconfig["mx_specs"] = get_mx_specs_defaults()
+
+    # Set mx_specs as if we ran qconfig_init
+    set_mx_specs(qconfig)
+
+    return qconfig
 
 
 @pytest.fixture(scope="function", params=default_config_params)
@@ -1080,3 +1184,66 @@ def model_bert():
         transformers.models.bert.modeling_bert.BertModel: BERT model
     """
     return BertModel.from_pretrained("google-bert/bert-base-uncased", torchscript=True)
+
+# MX reference class for quantization
+if torch.cuda.is_available():
+    class ResidualMLP(torch.nn.Module):
+        """
+        Test Linear model for MX library
+        """
+        def __init__(self, hidden_size, device="cuda"):
+            super(ResidualMLP, self).__init__()
+
+            self.layernorm = torch.nn.LayerNorm(hidden_size, device=device)
+            self.dense_4h = torch.nn.Linear(hidden_size, 4 * hidden_size, device=device)
+            self.dense_h = torch.nn.Linear(4 * hidden_size, hidden_size, device=device)
+            self.dummy = torch.nn.Linear(hidden_size, hidden_size, device=device)
+            # add a dummy layer because by default we skip 1st/last, if there are only 2 layers, all will be skipped
+
+        def forward(self, inputs):
+            norm_outputs = self.layernorm(inputs)
+
+            # MLP
+            proj_outputs = self.dense_4h(norm_outputs)
+            proj_outputs = F.gelu(proj_outputs)
+            mlp_outputs = self.dense_h(proj_outputs)
+            mlp_outputs = self.dummy(mlp_outputs)
+
+            # Residual Connection
+            outputs = inputs + mlp_outputs
+
+            return outputs
+
+mx_format_params = ["int8", "int4", "fp8_e4m3", "fp8_e5m2", "fp4_e2m1"]
+
+@pytest.fixture(scope="session", params=mx_format_params)
+def mx_format(request):
+    """
+    Get a MX element format to test
+
+    Returns:
+        str: MX element format name
+    """
+    return request.param
+
+
+@pytest.fixture(scope="function")
+def input_residualMLP():
+    """
+    Get a random input for a residual MLP model
+
+    Returns:
+        torch.FloatTensor: Random 16x128 tensor
+    """
+    x = np.random.randn(16, 128)
+    return torch.tensor(x, dtype=torch.float32, device="cuda")
+
+@pytest.fixture(scope="function")
+def model_residualMLP():
+    """
+    Get a ResidualMLP model
+
+    Returns:
+        torch.nn.Module: _description_
+    """
+    return ResidualMLP(128)

--- a/tests/models/test_model_utils.py
+++ b/tests/models/test_model_utils.py
@@ -26,8 +26,9 @@ from torch.nn import Conv2d, Linear
 import torch
 
 # Local
-from fms_mo.modules.conv import DetQConv2d, QConv2d, QConv2dPTQ, QConv2dPTQv2
-from fms_mo.modules.linear import QLinear
+from fms_mo.modules.conv import isinstance_qconv2d
+from fms_mo.modules.linear import isinstance_qlinear
+from fms_mo.prep import quantized_modules
 from fms_mo.utils.qconfig_utils import serialize_config
 
 logger = logging.getLogger(__name__)
@@ -35,11 +36,6 @@ logger = logging.getLogger(__name__)
 ####################
 # Helper Functions #
 ####################
-
-qconv2d_nodes = (QConv2d, QConv2dPTQ, QConv2dPTQv2, DetQConv2d)
-qlinear_nodes = QLinear
-
-quantized_nodes = (QConv2d, QConv2dPTQ, QConv2dPTQv2, QLinear, DetQConv2d)
 
 
 def is_qconv2d(node: torch.nn.Module):
@@ -52,7 +48,7 @@ def is_qconv2d(node: torch.nn.Module):
     Returns:
         bool: If node is in qconv2d_nodes
     """
-    return isinstance(node, qconv2d_nodes)
+    return isinstance_qconv2d(node)
 
 
 def is_qlinear(node: torch.nn.Module):
@@ -65,7 +61,7 @@ def is_qlinear(node: torch.nn.Module):
     Returns:
         bool: If node is in qlinear_nodes
     """
-    return isinstance(node, qlinear_nodes)
+    return isinstance_qlinear(node)
 
 
 def is_quantized_layer(node: torch.nn.Module):
@@ -78,7 +74,7 @@ def is_quantized_layer(node: torch.nn.Module):
     Returns:
         bool: If node is in quantized_nodes
     """
-    return isinstance(node, quantized_nodes)
+    return isinstance(node, quantized_modules)
 
 
 #########################
@@ -99,7 +95,7 @@ def count_qmodules(model: torch.nn.Module):
     """
     torch_modules, fms_qmodules = [], []
     for n, m in model.named_modules():
-        if isinstance(m, (QConv2d, QLinear)):
+        if is_quantized_layer(m):
             fms_qmodules.append((n, m))
         elif isinstance(m, (Conv2d, Linear)):
             torch_modules.append((n, m))

--- a/tests/models/test_mx.py
+++ b/tests/models/test_mx.py
@@ -1,0 +1,133 @@
+# Third Party
+import pytest
+import torch
+
+# Local
+from fms_mo import qmodel_prep
+from fms_mo.utils.qconfig_utils import check_config, set_mx_specs
+from fms_mo.utils.import_utils import available_packages
+from fms_mo.modules.linear import QLinearMX
+from fms_mo.modules.bmm import QBmmMX
+
+from tests.models.test_model_utils import delete_config, qmodule_error
+
+mx_qmodules = [
+    QLinearMX,
+    QBmmMX,
+]
+
+@pytest.mark.skipif(
+    not available_packages["mx"],
+    reason="Skipping mx_specs error test; No package found",
+)
+def test_config_mx_specs_error(
+    model_residualMLP: torch.nn.Module,
+    config_fp32_mx_specs: dict,
+    bad_mx_specs_settings: list,
+):
+    """
+    Check that mx_specs throw ValueError when presented with bad key,value pair
+
+    Args:
+        model_residualMLP (torch.nn.Module): Single fp32 model
+        config_fp32_mx_specs (dict): Config for fp32 quantization w/ mx_specs
+        bad_mx_specs_settings (list):
+            List of invalid values for mx_specs
+    """
+    model_dtype = next(model_residualMLP.parameters()).dtype
+
+    assert "mx_specs" in config_fp32_mx_specs
+    mx_specs_temp = config_fp32_mx_specs.get("mx_specs")
+
+    for key,bad_val in bad_mx_specs_settings:
+        # Every time we change the value, we must reset mx_specs
+        config_fp32_mx_specs["mx_specs"][key] = bad_val
+        set_mx_specs(config_fp32_mx_specs)
+
+        with pytest.raises(ValueError):
+            check_config(config_fp32_mx_specs, model_dtype)
+        
+        # Reset to saved value
+        config_fp32_mx_specs["mx_specs"] = mx_specs_temp
+
+@pytest.mark.skipif(
+    not available_packages["mx"],
+    reason="Skipping mx_specs error test; No package found",
+)
+def test_config_mx_error(
+    model_residualMLP: torch.nn.Module,
+    config_fp32_mx: dict,
+    bad_mx_config_settings: list,
+):
+    """
+    Check that mx_specs throw ValueError when presented with bad key,value pair
+
+    Args:
+        model_residualMLP (torch.nn.Module): Single fp32 model
+        config_fp32_mx (dict): Config for fp32 quantization w/ mx_specs
+        bad_mx_specs_settings (list):
+            List of invalid values for mx_specs
+    """
+    model_dtype = next(model_residualMLP.parameters()).dtype
+
+    assert "mx_specs" not in config_fp32_mx
+
+    for config_key, mx_specs_key, config_bad_val, mx_specs_bad_val in bad_mx_config_settings:
+        # Second check config w/ "mx_" prefix
+        mx_temp = config_fp32_mx[config_key]
+
+        # Need to reset qcfg["mx_specs"] w/ bad val
+        config_fp32_mx[config_key] = config_bad_val
+
+        set_mx_specs(config_fp32_mx)
+        assert "mx_specs" in config_fp32_mx
+        assert config_fp32_mx["mx_specs"][mx_specs_key] == mx_specs_bad_val
+
+        with pytest.raises(ValueError):
+            check_config(config_fp32_mx, model_dtype)
+
+        # Reset value and delete mx_specs
+        config_fp32_mx[config_key] = mx_temp
+        del config_fp32_mx["mx_specs"]
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    and not available_packages["mx"],
+    reason="Skipped because CUDA or MX library was not available",
+)
+def test_residualMLP(
+    model_residualMLP: torch.nn.Module,
+    input_residualMLP: torch.FloatTensor,
+    config_fp32_mx_specs: dict,
+    mx_format: str,
+):
+    """
+    Test residualMLP for qmodel_prep
+
+    Args:
+        model_residualMLP (torch.nn.Module): Single fp32 model.
+        input_residualMLP (torch.FloatTensor): Random 16x128 tensor.
+        config_fp32_mx_specs (dict): Config for fp32 quantization w/ mx_specs.
+        mx_format (str): MX format for quantization.
+    """
+    # Remove any saved qcfg.json
+    delete_config()
+
+    config_fp32_mx_specs["mx_specs"]["w_elem_format"] = mx_format
+    config_fp32_mx_specs["mx_specs"]["a_elem_format"] = mx_format
+    set_mx_specs(config_fp32_mx_specs)
+
+    qmodel_prep(model_residualMLP, input_residualMLP, config_fp32_mx_specs, use_dynamo=True)
+    qmodule_error(model_residualMLP, 2, 1)
+
+    # One layer should be QLinearMX
+    found_qmodule_mx = False
+    for _, module in model_residualMLP.named_modules():
+        if any( isinstance(module, qmodule_mx) for qmodule_mx in mx_qmodules ):
+            found_qmodule_mx = True
+            # Check that the desired mx format was propagated to class
+            assert module.mx_specs["w_elem_format"] == mx_format
+            assert module.mx_specs["a_elem_format"] == mx_format
+
+    assert found_qmodule_mx

--- a/tests/models/test_mx.py
+++ b/tests/models/test_mx.py
@@ -4,11 +4,10 @@ import torch
 
 # Local
 from fms_mo import qmodel_prep
-from fms_mo.utils.qconfig_utils import check_config, set_mx_specs
-from fms_mo.utils.import_utils import available_packages
-from fms_mo.modules.linear import QLinearMX
 from fms_mo.modules.bmm import QBmmMX
-
+from fms_mo.modules.linear import QLinearMX
+from fms_mo.utils.import_utils import available_packages
+from fms_mo.utils.qconfig_utils import check_config, set_mx_specs
 from tests.models.test_model_utils import delete_config, qmodule_error
 
 mx_qmodules = [
@@ -46,7 +45,7 @@ def test_config_mx_specs_error(
 
         with pytest.raises(ValueError):
             check_config(config_fp32_mx_specs, model_dtype)
-        
+
         # Reset to saved value
         config_fp32_mx_specs["mx_specs"] = mx_specs_temp
 


### PR DESCRIPTION
### Description of the change

Added logic for hooking in mx_specs to qconfig_init() and check_config().  Also adds a quick unit test to ensure everything is being set properly (tests/models/test_mx.py).

Also, minor changes to the modules quantized_nodes and prep.py.

### How to verify the PR

Run pytest in tests/models.

### Was the PR tested

All tests/models pass locally.